### PR TITLE
Move Jevnaker and Lunner from Innlandet to Viken

### DIFF
--- a/kommune_og_regionsreform_2017_2020.json
+++ b/kommune_og_regionsreform_2017_2020.json
@@ -460,6 +460,20 @@
         "gammeltNavn": "Nore og Uvdal",
         "nyttNavn": "Nore og Uvdal",
         "til": "3052"
+      },
+      {
+        "fra": "0532",
+        "dato": "2020-01-01",
+        "gammeltNavn": "Jevnaker",
+        "nyttNavn": "Jevnaker",
+        "til": "3053"
+      },
+      {
+        "fra": "0533",
+        "dato": "2020-01-01",
+        "gammeltNavn": "Lunner",
+        "nyttNavn": "Lunner",
+        "til": "3054"
       }
     ]
   },
@@ -742,20 +756,6 @@
         "gammeltNavn": "Vestre Toten",
         "nyttNavn": "Vestre Toten",
         "til": "3443"
-      },
-      {
-        "fra": "0532",
-        "dato": "2020-01-01",
-        "gammeltNavn": "Jevnaker",
-        "nyttNavn": "Jevnaker",
-        "til": "3444"
-      },
-      {
-        "fra": "0533",
-        "dato": "2020-01-01",
-        "gammeltNavn": "Lunner",
-        "nyttNavn": "Lunner",
-        "til": "3445"
       },
       {
         "fra": "0534",


### PR DESCRIPTION
In early 2018, Jevnaker and Lunner [decided to join Viken rather than Innlandet](https://www.nrk.no/ostlandssendingen/lunner-og-jevnaker-vil-til-viken----1.13885405)

[Updated list](https://www.regjeringen.no/no/tema/kommuner-og-regioner/kommunereform/nyekommuneogfylkesnummer/id2629203/)